### PR TITLE
Fix a number of issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can extend CLI functionality by using arguments. There are several:
 * profile Save Temporal AWS credentials using that profile name (If not used, data is prompted instead saved in file)
 * file Set a custom path to save the AWS credentials. (if not used, the default path is used)
 * ip To use in the SAML assertion.
-* samlApiVersion To set the version of OneLogin's SAML API to use. (options are: 1, 2)
+* saml-api-version To set the version of OneLogin's SAML API to use. (options are: 1, 2)
 
 _Note: If you're bored typing your
 username (`--username`),

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ aws-cli
   <dependency>
       <groupId>com.onelogin</groupId>
       <artifactId>onelogin-aws-assume-role-cli</artifactId>
-      <version>1.1.4</version>
+      <version>1.2.0</version>
   </dependency>
 ```
 
@@ -72,7 +72,7 @@ aws-jsp
   <dependency>
       <groupId>com.onelogin</groupId>
       <artifactId>onelogin-aws-assume-role-jsp</artifactId>
-      <version>1.1.4</version>
+      <version>1.2.0</version>
   </dependency>
 ```
 
@@ -159,6 +159,8 @@ You can extend CLI functionality by using arguments. There are several:
 * time Sleep time between iterations, in minutes (default value: 45) [Must be between 15 and 60]
 * profile Save Temporal AWS credentials using that profile name (If not used, data is prompted instead saved in file)
 * file Set a custom path to save the AWS credentials. (if not used, the default path is used)
+* ip To use in the SAML assertion.
+* samlApiVersion To set the version of OneLogin's SAML API to use. (options are: 1, 2)
 
 _Note: If you're bored typing your
 username (`--username`),

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ aws-cli
   <dependency>
       <groupId>com.onelogin</groupId>
       <artifactId>onelogin-aws-assume-role-cli</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
   </dependency>
 ```
 
@@ -72,7 +72,7 @@ aws-jsp
   <dependency>
       <groupId>com.onelogin</groupId>
       <artifactId>onelogin-aws-assume-role-jsp</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
   </dependency>
 ```
 

--- a/onelogin-aws-assume-role-cli/pom.xml
+++ b/onelogin-aws-assume-role-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.onelogin</groupId>
     <artifactId>onelogin-aws-assume-role</artifactId>
-    <version>1.1.4</version>
+    <version>1.2.0</version>
   </parent>
   <artifactId>onelogin-aws-assume-role-cli</artifactId>
   <!-- Output to jar format -->
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.onelogin</groupId>
       <artifactId>onelogin-java-sdk</artifactId>
-      <version>1.6.2</version>
+      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/onelogin-aws-assume-role-cli/pom.xml
+++ b/onelogin-aws-assume-role-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.onelogin</groupId>
     <artifactId>onelogin-aws-assume-role</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
   </parent>
   <artifactId>onelogin-aws-assume-role-cli</artifactId>
   <!-- Output to jar format -->

--- a/onelogin-aws-assume-role-jsp/pom.xml
+++ b/onelogin-aws-assume-role-jsp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.onelogin</groupId>
     <artifactId>onelogin-aws-assume-role</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
   </parent>
   <artifactId>onelogin-aws-assume-role-jsp</artifactId>
   <packaging>war</packaging>

--- a/onelogin-aws-assume-role-jsp/pom.xml
+++ b/onelogin-aws-assume-role-jsp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.onelogin</groupId>
     <artifactId>onelogin-aws-assume-role</artifactId>
-    <version>1.1.4</version>
+    <version>1.2.0</version>
   </parent>
   <artifactId>onelogin-aws-assume-role-jsp</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.onelogin</groupId>
   <artifactId>onelogin-aws-assume-role</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
   <packaging>pom</packaging>
   <name>onelogin-aws-assume-role</name>
   <description>Onelogin AWS Assume Role (Multi Account).</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.onelogin</groupId>
   <artifactId>onelogin-aws-assume-role</artifactId>
-  <version>1.1.4</version>
+  <version>1.2.0</version>
   <packaging>pom</packaging>
   <name>onelogin-aws-assume-role</name>
   <description>Onelogin AWS Assume Role (Multi Account).</description>


### PR DESCRIPTION
- Fixes issues with loop failing when using MFA (Users will probably have to re-enter otp)
- Update to latest OneLogin Java SDK (2.0.2)
- Allow using the OneLogin SAML2 APIs so that IP white listing can take effect (`--saml-api-version` to set between version 1 and 2)
- Allow setting the IP address used for the SAML assertion via argument (`--ip` to set the value)

Closes #17
Closes #41 