### PR TITLE
BUGFIX: Save region on config file

### DIFF
--- a/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
+++ b/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
@@ -496,13 +496,20 @@ public class OneloginAWSCLI {
 						profileName = "default";
 					}
 
-					Map<String, String> properties = new HashMap<String, String>();
-					properties.put(ProfileKeyConstants.AWS_ACCESS_KEY_ID, stsCredentials.getAccessKeyId());
-					properties.put(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, stsCredentials.getSecretAccessKey());
-					properties.put(ProfileKeyConstants.AWS_SESSION_TOKEN, stsCredentials.getSessionToken());
-					properties.put(ProfileKeyConstants.REGION, awsRegion);
+					// save credentials
+					Map<String, String> credentialsProperties = new HashMap<>();
+					credentialsProperties.put(ProfileKeyConstants.AWS_ACCESS_KEY_ID, stsCredentials.getAccessKeyId());
+					credentialsProperties.put(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, stsCredentials.getSecretAccessKey());
+					credentialsProperties.put(ProfileKeyConstants.AWS_SESSION_TOKEN, stsCredentials.getSessionToken());
 
-					ProfilesConfigFileWriter.modifyOneProfile(file, profileName, new Profile(profileName, properties, null));
+					ProfilesConfigFileWriter.modifyOneProfile(file, profileName, new Profile(profileName, credentialsProperties, null));
+
+					// save config
+					File configFile = AwsProfileFileLocationProvider.DEFAULT_CONFIG_LOCATION_PROVIDER.getLocation();
+					Map<String, String> regionProperties = new HashMap<>();
+					regionProperties.put(ProfileKeyConstants.REGION, awsRegion);
+
+					ProfilesConfigFileWriter.modifyOneProfile(configFile, profileName, new Profile(profileName, regionProperties, null));
 
 					System.out.println("\n-----------------------------------------------------------------------");
 					System.out.println("Success!\n");

--- a/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
+++ b/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
@@ -497,7 +497,7 @@ public class OneloginAWSCLI {
 					}
 
 					// save credentials
-					Map<String, String> credentialsProperties = new HashMap<>();
+					Map<String, String> credentialsProperties = new HashMap<String, String>();
 					credentialsProperties.put(ProfileKeyConstants.AWS_ACCESS_KEY_ID, stsCredentials.getAccessKeyId());
 					credentialsProperties.put(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, stsCredentials.getSecretAccessKey());
 					credentialsProperties.put(ProfileKeyConstants.AWS_SESSION_TOKEN, stsCredentials.getSessionToken());
@@ -506,7 +506,7 @@ public class OneloginAWSCLI {
 
 					// save config
 					File configFile = AwsProfileFileLocationProvider.DEFAULT_CONFIG_LOCATION_PROVIDER.getLocation();
-					Map<String, String> regionProperties = new HashMap<>();
+					Map<String, String> regionProperties = new HashMap<String, String>();
 					regionProperties.put(ProfileKeyConstants.REGION, awsRegion);
 
 					ProfilesConfigFileWriter.modifyOneProfile(configFile, profileName, new Profile(profileName, regionProperties, null));


### PR DESCRIPTION
<!---
Title your PR in the following format:
<Jira ticket number>: <short description>

Example:
ADMIN-1822: update navbar height to match portal

This is important to ensure the Jira ticket is kept in sync with automated processes
that are parsing the ticket number with regular expressions

Multiple ticket numbers also work:
ADMIN-1822, PORTAL-1343: unpdate nav bar heights in admin and portal
-->

This PR fix the configuration to store region information in the config file instead of the credentials file.

It resolves an issue where the `aws configure` command, while following aws best practice, did not work as expected after using the tool due to the priority of the credentials file.
> If there are credentials in both files for a profile sharing the same name, the keys in the credentials file take precedence.

[Configuration and credential file settings in the AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)