### PR TITLE
add --otp-token CLI flag for MFA

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ so your password won't be saved in you command line history.
 Please note that your password **will** be visible in your process list,
 if you use this flag (as the expanded command line arguments are part of the name of the process)._
 
+If your account is enrolled in MFA, you can also pass the one-time code as
+`--otp-token <code>`, which skips the interactive `Enter the OTP Token` prompt
+on the first attempt. The same process-list visibility caveat as `--password`
+applies: prefer piping from a TOTP CLI such as `oathtool`, for example
+`--otp-token $(oathtool --totp -b "$ONELOGIN_TOTP_SECRET")`. If the supplied
+code is rejected by OneLogin, the tool falls back to prompting interactively;
+the `--otp-token` value is **not** retried.
+
 For more info execute the --help option.
 
 ### JSP

--- a/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
+++ b/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
@@ -59,6 +59,7 @@ public class OneloginAWSCLI {
 	private static String oneloginRegion = "us";
 	private static String ip = null;
 	private static Integer samlApiVersion = 2;
+	private static String mfaOtpToken = null;
 
 	public static Boolean commandParser(final String[] commandLineArguments) {
 		final CommandLineParser cmd = new DefaultParser();
@@ -141,6 +142,13 @@ public class OneloginAWSCLI {
 				value = commandLine.getOptionValue("password");
 				if (value != null && !value.isEmpty()) {
 					oneloginPassword = value;
+				}
+			}
+
+			if (commandLine.hasOption("otp-token")) {
+				value = commandLine.getOptionValue("otp-token");
+				if (value != null && !value.isEmpty()) {
+					mfaOtpToken = value;
 				}
 			}
 
@@ -243,6 +251,7 @@ public class OneloginAWSCLI {
 		options.addOption("d", "subdomain", true, "OneLogin Instance Sub Domain.");
 		options.addOption("u", "username", true, "OneLogin username.");
 		options.addOption(null, "password", true, "OneLogin password.");
+		options.addOption(null, "otp-token", true, "OTP Token for MFA. Used for the first MFA attempt only; retries fall back to the interactive prompt.");
 		options.addOption(null, "aws-account-id", true, "AWS Account ID.");
 		options.addOption(null, "aws-role-name", true, "AWS Role Name.");
 		options.addOption("z", "duration", true, "Desired AWS Credential Duration");
@@ -607,8 +616,13 @@ public class OneloginAWSCLI {
 					deviceId = deviceSelection.getID();
 					deviceIdStr = deviceId.toString();
 
-					System.out.print("Enter the OTP Token for " + deviceSelection.getType() + ": ");
-					otpToken = scanner.next();
+					if (mfaOtpToken != null && !mfaOtpToken.isEmpty()) {
+						otpToken = mfaOtpToken;
+						mfaOtpToken = null;
+					} else {
+						System.out.print("Enter the OTP Token for " + deviceSelection.getType() + ": ");
+						otpToken = scanner.next();
+					}
 					mfaVerifyInfo = new HashMap<String, String>();
 					mfaVerifyInfo.put("otpToken", otpToken);
 					mfaVerifyInfo.put("deviceId", deviceIdStr);


### PR DESCRIPTION
## Summary
Closes #42.

Adds a `--otp-token <code>` CLI flag that lets users pass the MFA one-time code as an argument instead of being prompted interactively for it.

## Behavior
- When `--otp-token <code>` is provided, the first MFA attempt uses that code directly and skips the interactive `Enter the OTP Token` prompt.
- The value is **one-shot**: after first use it's cleared, so if OneLogin rejects the code, `verifyToken`'s retry path falls back to the interactive prompt rather than re-trying the same (presumably stale) value.
- `--loop` iterations 2+ continue to use the existing `mfaVerifyInfo` cache; the CLI value is not re-applied across iterations.
- If `--otp-token` is omitted, behavior is unchanged from today.

## README
Documented the new flag in the existing flags section, including a security caveat that mirrors the existing `--password` note about process-list visibility. Recommends composing with a TOTP CLI such as `oathtool`:

```
--otp-token $(oathtool --totp -b "$ONELOGIN_TOTP_SECRET")
```

## Test plan
- Local: `mvn clean compile` from `onelogin-aws-assume-role-cli/` — BUILD SUCCESS (no new warnings beyond the file's pre-existing deprecation/unchecked notices).
- No unit tests added — the repo has no existing test infrastructure under `src/test/`, and adding one for a single CLI flag would be out of scope for this fix.
- Manual verification recommended: a TOTP-enrolled OneLogin account, invoke with `--otp-token` set to a valid code and confirm no interactive prompt; invoke with a deliberately stale/wrong code and confirm fallback to interactive prompt rather than infinite loop.

## Not in this PR
- `onelogin-aws-assume-role-cli/dist/onelogin-aws-cli.jar` is **not** rebuilt in this diff. The plan for this triage round is to ship a single "rebuild + release" PR after all per-issue code PRs land, to avoid binary merge conflicts between concurrent flag PRs.