### PR TITLE
add --mfa-device-index CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ the tool won't ask for them any more._
 
 The selection of the AWS account and Role can be also be done with the --aws-account-id and --aws-role-name parameters.
 
+If your account has more than one MFA device enrolled and you always want to use
+the same one, pass `--mfa-device-index <n>` where `n` is the zero-based index
+shown in the interactive `Select the desired MFA Device [0-N]` prompt. If the
+index is out of range for the device list returned by OneLogin, the tool falls
+back to the interactive prompt.
+
 _Note: Specifying your password directly with `--password` is bad practice,
 you should use that flag together with password managers, eg. with the OSX Keychain:
 `--password $(security find-generic-password -a $USER -s onelogin -w)`,

--- a/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
+++ b/onelogin-aws-assume-role-cli/src/main/java/com/onelogin/aws/assume/role/cli/OneloginAWSCLI.java
@@ -59,6 +59,7 @@ public class OneloginAWSCLI {
 	private static String oneloginRegion = "us";
 	private static String ip = null;
 	private static Integer samlApiVersion = 2;
+	private static Integer mfaDeviceIndex = null;
 
 	public static Boolean commandParser(final String[] commandLineArguments) {
 		final CommandLineParser cmd = new DefaultParser();
@@ -141,6 +142,17 @@ public class OneloginAWSCLI {
 				value = commandLine.getOptionValue("password");
 				if (value != null && !value.isEmpty()) {
 					oneloginPassword = value;
+				}
+			}
+
+			if (commandLine.hasOption("mfa-device-index")) {
+				value = commandLine.getOptionValue("mfa-device-index");
+				if (value != null && !value.isEmpty()) {
+					try {
+						mfaDeviceIndex = Integer.valueOf(value);
+					} catch (NumberFormatException e) {
+						System.out.println("Warning: --mfa-device-index must be an integer; ignoring value: " + value);
+					}
 				}
 			}
 
@@ -243,6 +255,7 @@ public class OneloginAWSCLI {
 		options.addOption("d", "subdomain", true, "OneLogin Instance Sub Domain.");
 		options.addOption("u", "username", true, "OneLogin username.");
 		options.addOption(null, "password", true, "OneLogin password.");
+		options.addOption(null, "mfa-device-index", true, "Pre-select MFA device by zero-based index (skips the interactive device-selection prompt).");
 		options.addOption(null, "aws-account-id", true, "AWS Account ID.");
 		options.addOption(null, "aws-role-name", true, "AWS Role Name.");
 		options.addOption("z", "duration", true, "Desired AWS Credential Duration");
@@ -593,7 +606,12 @@ public class OneloginAWSCLI {
 					Integer deviceInput;
 					if (devices.size() == 1) {
 						deviceInput = 0;
+					} else if (mfaDeviceIndex != null && mfaDeviceIndex >= 0 && mfaDeviceIndex < devices.size()) {
+						deviceInput = mfaDeviceIndex;
 					} else {
+						if (mfaDeviceIndex != null) {
+							System.out.println("--mfa-device-index " + mfaDeviceIndex + " is out of range [0-" + (devices.size() - 1) + "]; falling back to interactive selection.");
+						}
 						for (int i = 0; i < devices.size(); i++) {
 							device = devices.get(i);
 							System.out.println(" " + i + " | " + device.getType());


### PR DESCRIPTION
## Summary
Closes #19.

Adds a `--mfa-device-index <n>` CLI flag that lets users pre-select an MFA device by zero-based index, avoiding the interactive `Select the desired MFA Device [0-N]` prompt when more than one device is enrolled.

## Behavior
- When `--mfa-device-index <n>` is provided and `n` is within range, the tool uses `devices.get(n)` directly and skips the device listing + prompt.
- If `n` is out of range for the device list returned by OneLogin, prints a notice and falls back to the interactive prompt. (Not a crash.)
- Non-integer values are rejected during CLI parsing with a `Warning:` line; the flag is treated as absent.
- The single-device auto-select path (`if (devices.size() == 1)`) takes precedence over the flag — passing `--mfa-device-index` on an account with only one device is a no-op.
- Unlike `--otp-token` from PR #54, the value persists across `--loop` iterations: the device choice is a stable user preference, OTP codes are not.
- If `--mfa-device-index` is omitted, behavior is unchanged from today.

## README
Documented the new flag in the existing flags section, with a note that out-of-range indices fall back to the interactive prompt.

## Test plan
- Local: `mvn clean compile` from `onelogin-aws-assume-role-cli/` — BUILD SUCCESS (no new warnings beyond the file's pre-existing deprecation/unchecked notices).
- No unit tests added — the repo has no existing test infrastructure under `src/test/`.
- Manual verification recommended on an account with 2+ MFA devices: with `--mfa-device-index 0` confirm the prompt is skipped and device 0 is used; with `--mfa-device-index 99` confirm the warning fires and interactive prompt appears; with `--mfa-device-index abc` confirm the CLI-parse warning fires and behavior matches the unflagged case.

## Not in this PR
- `onelogin-aws-assume-role-cli/dist/onelogin-aws-cli.jar` is **not** rebuilt — reserved for a final consolidation PR after all per-issue code PRs land, to avoid binary merge conflicts.